### PR TITLE
[Feature#46] 비밀번호 변경, 로그아웃 API 연결

### DIFF
--- a/app/src/main/java/com/example/mumuk/data/api/AuthApiService.kt
+++ b/app/src/main/java/com/example/mumuk/data/api/AuthApiService.kt
@@ -1,12 +1,16 @@
 package com.example.mumuk.data.api
 
 
+import com.example.mumuk.data.model.auth.CommonResponse
 import com.example.mumuk.data.model.auth.LoginRequest
 import com.example.mumuk.data.model.auth.LoginResponse
+import com.example.mumuk.data.model.auth.ReissuePwRequest
+import com.example.mumuk.data.model.auth.ReissuePwResponse
 import com.example.mumuk.data.model.auth.SignupRequest
 import com.example.mumuk.data.model.auth.SignupResponse
 import retrofit2.Call
 import retrofit2.http.Body
+import retrofit2.http.PATCH
 import retrofit2.http.POST
 
 interface AuthApiService {
@@ -14,5 +18,12 @@ interface AuthApiService {
     fun login(@Body request: LoginRequest): Call<LoginResponse>
     @POST("/api/auth/sign-up")
     fun signUp(@Body request: SignupRequest): Call<SignupResponse>
+    @PATCH("/api/auth/reissue-pw")
+    fun reissuePassword(@Body request: ReissuePwRequest): Call<ReissuePwResponse>
+    @PATCH("/api/auth/logout")
+    fun logout(
+        @retrofit2.http.Header("X-Refresh-Token") refreshToken: String,
+        @retrofit2.http.Header("X-Login-Type") loginType: String = "LOCAL"
+    ): Call<CommonResponse>
 
 }

--- a/app/src/main/java/com/example/mumuk/data/model/auth/CommonResponse.kt
+++ b/app/src/main/java/com/example/mumuk/data/model/auth/CommonResponse.kt
@@ -1,0 +1,8 @@
+package com.example.mumuk.data.model.auth
+
+data class CommonResponse(
+    val status: String,
+    val code: String,
+    val message: String,
+    val data: String?
+)

--- a/app/src/main/java/com/example/mumuk/data/model/auth/ReissuePwRequest.kt
+++ b/app/src/main/java/com/example/mumuk/data/model/auth/ReissuePwRequest.kt
@@ -1,0 +1,6 @@
+package com.example.mumuk.data.model.auth
+
+data class ReissuePwRequest(
+    val passWord: String,
+    val confirmPassWord: String
+)

--- a/app/src/main/java/com/example/mumuk/data/model/auth/ReissuePwResponse.kt
+++ b/app/src/main/java/com/example/mumuk/data/model/auth/ReissuePwResponse.kt
@@ -1,0 +1,8 @@
+package com.example.mumuk.data.model.auth
+
+data class ReissuePwResponse(
+    val status: String,
+    val code: String,
+    val message: String,
+    val data: String
+)

--- a/app/src/main/java/com/example/mumuk/ui/login/ChangePwFragment.kt
+++ b/app/src/main/java/com/example/mumuk/ui/login/ChangePwFragment.kt
@@ -11,9 +11,16 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.Window
 import android.widget.TextView
+import android.widget.Toast
 import androidx.fragment.app.Fragment
 import com.example.mumuk.R
+import com.example.mumuk.data.api.RetrofitClient
+import com.example.mumuk.data.model.auth.ReissuePwRequest
+import com.example.mumuk.data.model.auth.ReissuePwResponse
 import com.example.mumuk.databinding.FragmentChangePwBinding
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.Response
 
 class ChangePwFragment : Fragment() {
 
@@ -62,8 +69,28 @@ class ChangePwFragment : Fragment() {
                 binding.tvPwStatus.text = "비밀번호가 일치하지 않습니다"
             } else {
                 binding.tvPwStatus.text = ""
-                showPasswordChangedDialog()
+
+                val request = ReissuePwRequest(passWord = pw, confirmPassWord = pwNew)
+
+                RetrofitClient.getAuthApi(requireContext()).reissuePassword(request)
+                    .enqueue(object : Callback<ReissuePwResponse> {
+                        override fun onResponse(
+                            call: Call<ReissuePwResponse>,
+                            response: Response<ReissuePwResponse>
+                        ) {
+                            if (response.isSuccessful && response.body()?.status == "100 CONTINUE") {
+                                showPasswordChangedDialog()
+                            } else {
+                                Toast.makeText(requireContext(), "비밀번호 재설정 실패: ${response.body()?.message}", Toast.LENGTH_SHORT).show()
+                            }
+                        }
+
+                        override fun onFailure(call: Call<ReissuePwResponse>, t: Throwable) {
+                            Toast.makeText(requireContext(), "네트워크 오류: ${t.message}", Toast.LENGTH_SHORT).show()
+                        }
+                    })
             }
+
         }
 
     }

--- a/app/src/main/java/com/example/mumuk/ui/mypage/SubChangePw2Fragment.kt
+++ b/app/src/main/java/com/example/mumuk/ui/mypage/SubChangePw2Fragment.kt
@@ -13,8 +13,14 @@ import android.view.Window
 import android.widget.TextView
 import androidx.fragment.app.Fragment
 import com.example.mumuk.R
+import com.example.mumuk.data.api.RetrofitClient
+import com.example.mumuk.data.model.auth.ReissuePwRequest
+import com.example.mumuk.data.model.auth.ReissuePwResponse
 import com.example.mumuk.databinding.FragmentChangePwBinding
 import com.example.mumuk.ui.mypage.MyPageFragment
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.Response
 
 class SubChangePw2Fragment : Fragment() {
 
@@ -63,8 +69,30 @@ class SubChangePw2Fragment : Fragment() {
                 binding.tvPwStatus.text = "비밀번호가 일치하지 않습니다"
             } else {
                 binding.tvPwStatus.text = ""
-                showPasswordChangedDialog()
+
+                val request = ReissuePwRequest(passWord = pw, confirmPassWord = pwNew)
+
+                RetrofitClient.getAuthApi(requireContext()).reissuePassword(request)
+                    .enqueue(object : Callback<ReissuePwResponse> {
+                        override fun onResponse(
+                            call: Call<ReissuePwResponse>,
+                            response: Response<ReissuePwResponse>
+                        ) {
+                            val result = response.body()
+                            if (response.isSuccessful && result?.message?.contains("성공") == true) {
+                                showPasswordChangedDialog()
+                            } else {
+                                binding.tvPwStatus.text = "변경 실패: ${result?.message ?: "서버 응답 없음"}"
+                            }
+
+                        }
+
+                        override fun onFailure(call: Call<ReissuePwResponse>, t: Throwable) {
+                            binding.tvPwStatus.text = "네트워크 오류: ${t.message}"
+                        }
+                    })
             }
+
         }
 
     }


### PR DESCRIPTION
## ✔️ 작업 내용
- 비밀번호 재설정 API 연결
- 로그아웃 API 연결

🔨 상세 작업 내용
- 비밀번호 재설정 API 연결하기
- 로그아웃 API 연결하기

📄 참고 사항
- 기존 비밀번호 확인 기능은 추후에 추가 예정 ( 비밀번호 변경 전 확인 용도 )