### PR TITLE
[Fix/#85] refreshToken 자동 로그인처리

### DIFF
--- a/app/src/main/java/com/example/mumuk/IntroActivity.kt
+++ b/app/src/main/java/com/example/mumuk/IntroActivity.kt
@@ -29,12 +29,31 @@ class IntroActivity : AppCompatActivity() {
 
         val prefs = getSharedPreferences("auth", MODE_PRIVATE)
         val refreshToken = prefs.getString("refreshToken", null)
+        val loginType = prefs.getString("loginType", "LOCAL") ?: "LOCAL"
 
-        // 자동 로그인 처리
         if (refreshToken != null) {
-            Log.d("AutoLogin", "저장된 refreshToken 발견 → 자동 로그인")
-            startActivity(Intent(this, MainActivity::class.java))
-            finish()
+            CoroutineScope(Dispatchers.IO).launch {
+                try {
+                    val response = RetrofitClient.getAuthApi(this@IntroActivity)
+                        .reissueToken(refreshToken, loginType)
+                    withContext(Dispatchers.Main) {
+                        if (response.isSuccessful && response.body()?.data != null) {
+                            val tokenData = response.body()!!.data!!
+                            TokenManager.saveTokens(this@IntroActivity, tokenData.accessToken, tokenData.refreshToken)
+                            startActivity(Intent(this@IntroActivity, MainActivity::class.java))
+                            finish()
+                        } else {
+                            TokenManager.clearTokens(this@IntroActivity)
+                            fallbackToLogin("세션이 만료되었습니다. 다시 로그인 해주세요.")
+                        }
+                    }
+                } catch (e: Exception) {
+                    withContext(Dispatchers.Main) {
+                        TokenManager.clearTokens(this@IntroActivity)
+                        fallbackToLogin("자동 로그인 실패: 네트워크 오류")
+                    }
+                }
+            }
             return
         }
 

--- a/app/src/main/java/com/example/mumuk/data/api/AuthApiService.kt
+++ b/app/src/main/java/com/example/mumuk/data/api/AuthApiService.kt
@@ -52,10 +52,9 @@ interface AuthApiService {
         @Query("state") state: String = "mumukDefaultState"
     ): Response<NaverLoginResponse>
 
-
-
-
-
-
-
+    @POST("/api/auth/reissue")
+    suspend fun reissueToken(
+        @Header("X-Refresh-Token") refreshToken: String,
+        @Header("X-Login-Type") loginType: String
+    ): Response<LoginResponse>
 }


### PR DESCRIPTION
## ✔️ 작업 내용
- 기존 refreshToken이 존재하면 자동 로그인 하는 구조 삭제
- refreshToken을 통해 accessToken을 새로 발급하는 API 연결

## 💬 참고 사항 <!-- 리뷰어에게 할 말을 작성해주세요. -->
- 소셜 로그인의 경우 해당 로직이 적용되지 않습니다. 현재 소셜 로그인은 다른 api도 동작을 하지 않는 것을 발견하였는데 추후 이와 관련된 논의가 필요할 것으로 보입니다.