### PR TITLE
[Feature/#101] 레시피 상세 조회 API

### DIFF
--- a/.kotlin/errors/errors-1754211989030.log
+++ b/.kotlin/errors/errors-1754211989030.log
@@ -1,0 +1,4 @@
+kotlin version: 2.0.21
+error message: The daemon has terminated unexpectedly on startup attempt #1 with error code: 0. The daemon process output:
+    1. Kotlin compile daemon is ready
+

--- a/app/src/main/java/com/example/mumuk/data/api/RetrofitClient.kt
+++ b/app/src/main/java/com/example/mumuk/data/api/RetrofitClient.kt
@@ -2,7 +2,6 @@ package com.example.mumuk.data.api
 
 import android.content.Context
 import okhttp3.OkHttpClient
-import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 
@@ -12,14 +11,8 @@ object RetrofitClient {
 
     private fun getRetrofit(context: Context): Retrofit {
         if (retrofit == null) {
-            // 1. HttpLoggingInterceptor 추가
-            val logging = HttpLoggingInterceptor().apply {
-                // 개발 중엔 BODY, 운영 배포 땐 필요한 경우 INFO/ERROR로
-                level = HttpLoggingInterceptor.Level.BODY
-            }
             val client = OkHttpClient.Builder()
                 .addInterceptor(AuthInterceptor(context))
-                .addInterceptor(logging) // 2. loggingInterceptor 추가
                 .build()
 
             retrofit = Retrofit.Builder()
@@ -34,6 +27,8 @@ object RetrofitClient {
     fun getAuthApi(context: Context): AuthApiService {
         return getRetrofit(context).create(AuthApiService::class.java)
     }
+
+    //TODO: 다른 api도 getAuthApi처럼 get~~Api 와 같이 추가해서 쓰기
 
     fun getUserApi(context: Context): UserApiService {
         return getRetrofit(context).create(UserApiService::class.java)

--- a/app/src/main/java/com/example/mumuk/data/api/UserRecipeApiService.kt
+++ b/app/src/main/java/com/example/mumuk/data/api/UserRecipeApiService.kt
@@ -2,11 +2,20 @@ package com.example.mumuk.data.api
 
 import com.example.mumuk.data.model.recipe.ClickLikeRequest
 import com.example.mumuk.data.model.recipe.ClickLikeResponse
+import com.example.mumuk.data.model.search.UserRecipeDetailResponse
 import retrofit2.Call
+import retrofit2.Response
 import retrofit2.http.Body
+import retrofit2.http.GET
 import retrofit2.http.POST
+import retrofit2.http.Path
 
 interface UserRecipeApiService {
     @POST("/api/user-recipe/click-like")
     fun clickLike(@Body request: ClickLikeRequest): Call<ClickLikeResponse>
+
+    @GET("/api/user-recipe/{recipeId}")
+    suspend fun getUserRecipeDetail(
+        @Path("recipeId") recipeId: Long
+    ): Response<UserRecipeDetailResponse>
 }

--- a/app/src/main/java/com/example/mumuk/data/model/RecipeIngredient.kt
+++ b/app/src/main/java/com/example/mumuk/data/model/RecipeIngredient.kt
@@ -1,6 +1,9 @@
 package com.example.mumuk.data.model
 
+import com.google.gson.annotations.SerializedName
+
 data class RecipeIngredient(
     val name: String,
+    @SerializedName("inFridge")
     val isAvailable: Boolean
 )

--- a/app/src/main/java/com/example/mumuk/data/model/search/UserRecipeDetailData.kt
+++ b/app/src/main/java/com/example/mumuk/data/model/search/UserRecipeDetailData.kt
@@ -1,0 +1,24 @@
+package com.example.mumuk.data.model.search
+
+import com.example.mumuk.data.model.RecipeIngredient
+
+data class UserRecipeDetailData(
+    val id: Long,
+    val title: String,
+    val recipeImage: String,
+    val description: String,
+    val cookingTime: Int,
+    val calories: Int,
+    val protein: Int,
+    val carbohydrate: Int,
+    val fat: Int,
+    val categories: List<String>,
+    val ingredients: String,
+    val sourceUrl: String,
+    val recipeIngredients: List<RecipeIngredient>,
+    val inFridgeIngredients: List<String>,
+    val notInFridgeIngredients: List<String>,
+    val viewed: Boolean,
+    val viewedAt: String?,
+    val liked: Boolean
+)

--- a/app/src/main/java/com/example/mumuk/data/model/search/UserRecipeDetailResponse.kt
+++ b/app/src/main/java/com/example/mumuk/data/model/search/UserRecipeDetailResponse.kt
@@ -1,0 +1,8 @@
+package com.example.mumuk.data.model.search
+
+data class UserRecipeDetailResponse(
+    val status: String,
+    val code: String,
+    val message: String,
+    val data: UserRecipeDetailData
+)

--- a/app/src/main/java/com/example/mumuk/data/repository/UserRecipeRepository.kt
+++ b/app/src/main/java/com/example/mumuk/data/repository/UserRecipeRepository.kt
@@ -1,0 +1,18 @@
+package com.example.mumuk.data.repository
+
+import android.content.Context
+import android.util.Log
+import com.example.mumuk.data.api.RetrofitClient
+import com.example.mumuk.data.model.search.UserRecipeDetailResponse
+import retrofit2.Response
+
+class UserRecipeRepository(private val context: Context) {
+    private val api = RetrofitClient.getUserRecipeApi(context)
+
+    suspend fun getUserRecipeDetail(recipeId: Long): Response<UserRecipeDetailResponse> {
+        Log.d("UserRecipeRepository", "getUserRecipeDetail() called with recipeId: $recipeId")
+        val response = api.getUserRecipeDetail(recipeId)
+        Log.d("UserRecipeRepository", "API response: isSuccessful=${response.isSuccessful}, code=${response.code()}")
+        return response
+    }
+}

--- a/app/src/main/java/com/example/mumuk/ui/recipe/RecipeFragment.kt
+++ b/app/src/main/java/com/example/mumuk/ui/recipe/RecipeFragment.kt
@@ -1,10 +1,11 @@
 package com.example.mumuk.ui.recipe
 
 import android.os.Bundle
-import androidx.fragment.app.Fragment
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.GridLayoutManager
@@ -27,7 +28,9 @@ class RecipeFragment : Fragment() {
     private var _binding: FragmentRecipeBinding? = null
     private val binding get() = _binding!!
 
-    private val recipeViewModel: RecipeViewModel by viewModels()
+    private val recipeViewModel: RecipeViewModel by viewModels {
+        RecipeViewModel.Factory(requireContext())
+    }
 
     private var currentRecipe: Recipe? = null
 
@@ -58,6 +61,7 @@ class RecipeFragment : Fragment() {
 
         recipeViewModel.allIngredients.observe(viewLifecycleOwner) { ingredients ->
             ingredientRV.adapter = IngredientAdapter(ingredients)
+            Log.d("RecipeFragment", "Ingredients updated: $ingredients")
         }
 
         fullBlogList = BlogRepository.getBlogList()
@@ -79,7 +83,17 @@ class RecipeFragment : Fragment() {
 
         recipeViewModel.shopItemList.observe(viewLifecycleOwner) { shopList ->
             shopAdapter.submitList(shopList)
+            Log.d("RecipeFragment", "Shop items updated: $shopList")
         }
+
+        recipeViewModel.userRecipeDetail.observe(viewLifecycleOwner) { detail ->
+            Log.d("RecipeFragment", "UserRecipeDetail 업데이트: $detail")
+            binding.recipeTitle.text = detail.title
+        }
+
+        val recipeId = arguments?.getLong("recipeId") ?: 4L
+        Log.d("RecipeFragment", "onViewCreated() - recipeId: $recipeId")
+        recipeViewModel.fetchRecipeDetail(recipeId)
 
         recipeViewModel.selectedRecipe.observe(viewLifecycleOwner) { recipe ->
             currentRecipe = recipe
@@ -108,14 +122,14 @@ class RecipeFragment : Fragment() {
                         call: Call<ClickLikeResponse>,
                         response: Response<ClickLikeResponse>
                     ) {
-                        // 성공 처리 (필요 시)
+                        Log.d("RecipeFragment", "Like API success: ${response.body()}")
                     }
 
                     override fun onFailure(
                         call: Call<ClickLikeResponse>,
                         t: Throwable
                     ) {
-                        // 실패 처리 (필요 시)
+                        Log.e("RecipeFragment", "Like API error: ${t.localizedMessage}", t)
                     }
                 })
             }

--- a/app/src/main/java/com/example/mumuk/ui/recipe/RecipeViewModel.kt
+++ b/app/src/main/java/com/example/mumuk/ui/recipe/RecipeViewModel.kt
@@ -1,18 +1,19 @@
 package com.example.mumuk.ui.recipe
 
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
+import android.content.Context
+import android.util.Log
+import androidx.lifecycle.*
 import com.example.mumuk.data.model.NutritionInfo
 import com.example.mumuk.data.model.ShopItem
 import com.example.mumuk.data.model.Recipe
 import com.example.mumuk.data.model.RecipeIngredient
+import com.example.mumuk.data.model.search.UserRecipeDetailData
 import com.example.mumuk.data.repository.RecipeIngredientRepository
 import com.example.mumuk.data.repository.ShopRepository
+import com.example.mumuk.data.repository.UserRecipeRepository
 import kotlinx.coroutines.launch
 
-class RecipeViewModel : ViewModel() {
+class RecipeViewModel(private val userRecipeRepository: UserRecipeRepository) : ViewModel() {
 
     private val shopRepository = ShopRepository()
     private val ingredientRepository = RecipeIngredientRepository()
@@ -31,6 +32,9 @@ class RecipeViewModel : ViewModel() {
 
     private val _allIngredients = MutableLiveData<List<RecipeIngredient>>()
     val allIngredients: LiveData<List<RecipeIngredient>> = _allIngredients
+
+    private val _userRecipeDetail = MutableLiveData<UserRecipeDetailData>()
+    val userRecipeDetail: LiveData<UserRecipeDetailData> = _userRecipeDetail
 
     init {
         loadShopItems()
@@ -63,5 +67,37 @@ class RecipeViewModel : ViewModel() {
 
     fun selectRecipe(recipe: Recipe) {
         _selectedRecipe.value = recipe
+    }
+
+    fun fetchRecipeDetail(recipeId: Long) {
+        Log.d("RecipeViewModel", "fetchRecipeDetail() called with recipeId: $recipeId")
+        viewModelScope.launch {
+            try {
+                val response = userRecipeRepository.getUserRecipeDetail(recipeId)
+                if (response.isSuccessful) {
+                    Log.d("RecipeViewModel", "API success. Response body: ${response.body()}")
+                    response.body()?.data?.let {
+                        Log.d("RecipeViewModel", "Parsed detail data: $it")
+                        _userRecipeDetail.value = it
+                    }
+                } else {
+                    Log.e("RecipeViewModel", "API error: code=${response.code()}, message=${response.message()}")
+                }
+            } catch (e: Exception) {
+                Log.e("RecipeViewModel", "Exception in fetchRecipeDetail: ${e.localizedMessage}", e)
+            }
+        }
+    }
+
+    class Factory(private val context: Context) :
+        ViewModelProvider.Factory {
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            if (modelClass.isAssignableFrom(RecipeViewModel::class.java)) {
+                val repo = UserRecipeRepository(context)
+                @Suppress("UNCHECKED_CAST")
+                return RecipeViewModel(repo) as T
+            }
+            throw IllegalArgumentException("Unknown ViewModel class")
+        }
     }
 }

--- a/app/src/main/res/layout/fragment_search_result.xml
+++ b/app/src/main/res/layout/fragment_search_result.xml
@@ -5,53 +5,60 @@
     android:layout_height="match_parent"
     android:background="@android:color/white">
 
-    <ImageView
-        android:id="@+id/search_result_back_btn"
-        android:layout_width="30dp"
-        android:layout_height="30dp"
-        android:src="@drawable/ic_category_back"
-        android:padding="4dp"
-        android:layout_marginStart="16dp"
-        android:layout_marginTop="12dp"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toTopOf="@id/search_result_rv" />
-
     <LinearLayout
-        android:id="@+id/search_bar_container"
+        android:id="@+id/search_top_row"
         android:layout_width="0dp"
         android:layout_height="40dp"
         android:orientation="horizontal"
         android:gravity="center_vertical"
-        android:background="@drawable/bg_search_frame"
-        android:layout_marginStart="5dp"
+        android:background="@android:color/transparent"
+        android:layout_marginTop="12dp"
+        android:layout_marginStart="16dp"
         android:layout_marginEnd="14dp"
-        app:layout_constraintStart_toEndOf="@id/search_result_back_btn"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="@id/search_result_back_btn"
-        app:layout_constraintBottom_toBottomOf="@id/search_result_back_btn">
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
 
-        <EditText
-            android:id="@+id/search_result_edit_et"
+        <ImageView
+            android:id="@+id/search_result_back_btn"
+            android:layout_width="30dp"
+            android:layout_height="30dp"
+            android:src="@drawable/ic_category_back"
+            android:padding="4dp"
+            android:layout_gravity="center_vertical"/>
+
+        <LinearLayout
+            android:id="@+id/search_bar_container"
             android:layout_width="0dp"
             android:layout_height="match_parent"
             android:layout_weight="1"
-            android:hint="검색어를 입력하세요"
-            android:background="@android:color/transparent"
-            android:padding="0dp"
-            android:textSize="16sp"
-            android:fontFamily="@font/pretendard_medium"
-            android:inputType="text"
-            android:imeOptions="actionSearch"
-            android:singleLine="true"
-            android:layout_marginStart="10dp"/>
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:layout_marginStart="5dp"
+            android:background="@drawable/bg_search_frame">
 
-        <ImageView
-            android:id="@+id/search_result_btn"
-            android:layout_width="20dp"
-            android:layout_height="20dp"
-            android:src="@drawable/ic_search"
-            android:layout_marginEnd="8dp" />
+            <EditText
+                android:id="@+id/search_result_edit_et"
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:hint="검색어를 입력하세요"
+                android:background="@android:color/transparent"
+                android:padding="0dp"
+                android:textSize="16sp"
+                android:fontFamily="@font/pretendard_medium"
+                android:inputType="text"
+                android:imeOptions="actionSearch"
+                android:singleLine="true"
+                android:layout_marginStart="10dp"/>
+
+            <ImageView
+                android:id="@+id/search_result_btn"
+                android:layout_width="20dp"
+                android:layout_height="20dp"
+                android:src="@drawable/ic_search"
+                android:layout_marginEnd="8dp" />
+        </LinearLayout>
     </LinearLayout>
 
     <androidx.recyclerview.widget.RecyclerView
@@ -62,15 +69,15 @@
         android:padding="8dp"
         android:layout_marginStart="16dp"
         android:layout_marginTop="8dp"
-        app:layout_constraintTop_toBottomOf="@id/search_bar_container"
+        app:layout_constraintTop_toBottomOf="@id/search_top_row"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
 
     <TextView
         android:id="@+id/search_result_empty"
-        android:layout_width="260dp"
-        android:layout_height="211dp"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
         android:gravity="center"
         android:text="검색 결과가 없습니다.\n다시 입력해주세요."
         android:textAlignment="center"
@@ -78,7 +85,7 @@
         android:textColor="#FF4B2B"
         android:textSize="16sp"
         android:visibility="gone"
-        app:layout_constraintTop_toBottomOf="@id/search_bar_container"
+        app:layout_constraintTop_toBottomOf="@id/search_top_row"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"/>


### PR DESCRIPTION
## ✔️ 작업 내용
- 레시피 아이템 클릭 시 상세 레시피로 이동하는 API 연결

## 💬 참고 사항 <!-- 리뷰어에게 할 말을 작성해주세요. -->
- 레시피 이동 API는 정상적으로 연결
- 현재 API 구조상, 이미 조회한 레시피는 user_recipe 테이블에 등록되고,
   다시 해당 레시피를 상세조회할 경우 중복 등록으로 인해 조회 불가능
