### PR TITLE
[Refactor#203] 재료 맞춤 추천 화면 Glide 연결 및 로딩화면 로직 수정

### DIFF
--- a/app/src/main/java/com/example/mumuk/ui/recommend/HealthAiAdapter.kt
+++ b/app/src/main/java/com/example/mumuk/ui/recommend/HealthAiAdapter.kt
@@ -1,9 +1,12 @@
 package com.example.mumuk.ui.recommend
 
+import android.graphics.drawable.Drawable
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
+import com.bumptech.glide.load.engine.GlideException
+import com.bumptech.glide.request.RequestListener
 import com.example.mumuk.data.model.Recipe
 import com.example.mumuk.databinding.ItemRecipeBinding
 import com.example.mumuk.data.api.RetrofitClient
@@ -12,10 +15,12 @@ import com.example.mumuk.data.model.recipe.ClickLikeResponse
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
+import com.bumptech.glide.load.DataSource
 
 class HealthAiAdapter(
     private var items: MutableList<Recipe>,
-    private val onItemClick: (Recipe) -> Unit
+    private val onItemClick: (Recipe) -> Unit,
+    private val onImageLoaded: () -> Unit
 ) : RecyclerView.Adapter<HealthAiAdapter.ViewHolder>() {
 
     inner class ViewHolder(val binding: ItemRecipeBinding) : RecyclerView.ViewHolder(binding.root) {
@@ -27,6 +32,28 @@ class HealthAiAdapter(
                     .load(it)
                     .placeholder(com.example.mumuk.R.drawable.bg_mosaic)
                     .error(com.example.mumuk.R.drawable.bg_mosaic)
+                    .listener(object : RequestListener<Drawable> {
+                        override fun onLoadFailed(
+                            e: GlideException?,
+                            model: Any?,
+                            target: com.bumptech.glide.request.target.Target<Drawable?>,
+                            isFirstResource: Boolean
+                        ): Boolean {
+                            onImageLoaded()
+                            return false
+                        }
+
+                        override fun onResourceReady(
+                            resource: Drawable,
+                            model: Any,
+                            target: com.bumptech.glide.request.target.Target<Drawable?>?,
+                            dataSource: DataSource,
+                            isFirstResource: Boolean
+                        ): Boolean {
+                            onImageLoaded()
+                            return false
+                        }
+                    })
                     .into(binding.recipeImg)
             }
 

--- a/app/src/main/java/com/example/mumuk/ui/recommend/HealthRecommendFragment.kt
+++ b/app/src/main/java/com/example/mumuk/ui/recommend/HealthRecommendFragment.kt
@@ -37,6 +37,7 @@ import kotlinx.coroutines.launch
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
+import java.util.concurrent.atomic.AtomicInteger
 
 class HealthRecommendFragment : Fragment() {
     private var _binding: FragmentHealthRecommendBinding? = null
@@ -53,6 +54,8 @@ class HealthRecommendFragment : Fragment() {
 
     private lateinit var allergyApi: AllergyApiService
     private lateinit var healthApi: HealthApiService
+
+    private var imageLoadCounter: AtomicInteger? = null
 
     private val pickImageLauncher = registerForActivityResult(
         ActivityResultContracts.GetContent()
@@ -87,9 +90,6 @@ class HealthRecommendFragment : Fragment() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        if (aiRecipeList.isEmpty()) {
-            loadAiRecipes()
-        }
     }
 
     override fun onCreateView(
@@ -104,7 +104,6 @@ class HealthRecommendFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         setupRecyclerView()
-        updateAiRecipeList()
 
         binding.backBtn.setOnClickListener {
             findNavController().popBackStack()
@@ -197,6 +196,11 @@ class HealthRecommendFragment : Fragment() {
                 Log.d("HealthRecommend", "Recipe clicked. ID: ${recipe.id}")
                 val bundle = bundleOf("recipeId" to recipe.id)
                 findNavController().navigate(R.id.action_healthRecommendFragment_to_recipeFragment, bundle)
+            },
+            onImageLoaded = {
+                if (imageLoadCounter?.decrementAndGet() == 0) {
+                    binding.loadingOverlay.hide()
+                }
             }
         )
 
@@ -211,7 +215,6 @@ class HealthRecommendFragment : Fragment() {
                 isExpanded = false
                 if (_binding != null) {
                     updateAiRecipeList()
-                    binding.loadingOverlay.hide()
                 }
             } catch (e: Exception) {
                 if (_binding != null) {
@@ -229,6 +232,13 @@ class HealthRecommendFragment : Fragment() {
         } else {
             aiRecipeList
         }
+
+        if (itemsToShow.isNotEmpty()) {
+            imageLoadCounter = AtomicInteger(itemsToShow.size)
+        } else {
+            binding.loadingOverlay.hide()
+        }
+
         aiRecipeAdapter.updateList(itemsToShow.toMutableList())
         binding.plusBtn.visibility = if (aiRecipeList.size > 6 && !isExpanded) View.VISIBLE else View.GONE
     }

--- a/app/src/main/java/com/example/mumuk/ui/recommend/HealthRecommendFragment.kt
+++ b/app/src/main/java/com/example/mumuk/ui/recommend/HealthRecommendFragment.kt
@@ -14,10 +14,8 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.LinearLayout
-import android.widget.TextView
 import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.cardview.widget.CardView
 import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
@@ -56,6 +54,7 @@ class HealthRecommendFragment : Fragment() {
     private lateinit var healthApi: HealthApiService
 
     private var imageLoadCounter: AtomicInteger? = null
+    private var onImagesLoadedAction: (() -> Unit)? = null
 
     private val pickImageLauncher = registerForActivityResult(
         ActivityResultContracts.GetContent()
@@ -63,7 +62,6 @@ class HealthRecommendFragment : Fragment() {
         uri?.let {
             val fileName = getFileName(it)
             binding.imgText.text = fileName ?: "image.jpg"
-
             uploadImageToServer(it)
         }
     }
@@ -121,11 +119,13 @@ class HealthRecommendFragment : Fragment() {
         allergyApi = RetrofitClient.getAllergyApi(requireContext())
         healthApi = RetrofitClient.getHealthApi(requireContext())
 
-        // filterContainer 초기화
         filterContainer = binding.root.findViewById(R.id.filterContainer)
         fetchAndDisplayFilters()
 
         binding.loadingOverlay.show()
+        onImagesLoadedAction = {
+            binding.loadingOverlay.hide()
+        }
         loadAiRecipes()
     }
 
@@ -167,7 +167,6 @@ class HealthRecommendFragment : Fragment() {
             val cardBinding = com.example.mumuk.databinding.ItemFilterCardBinding.inflate(inflater)
             cardBinding.filterText.text = filterText
 
-            // 첫 번째 카드에만 marginStart 20dp 적용
             val params = LinearLayout.LayoutParams(
                 LinearLayout.LayoutParams.WRAP_CONTENT,
                 LinearLayout.LayoutParams.WRAP_CONTENT
@@ -177,7 +176,7 @@ class HealthRecommendFragment : Fragment() {
             } else {
                 params.marginStart = 0
             }
-            params.marginEnd = dpToPx(8) // 기존 marginEnd 8dp도 적용
+            params.marginEnd = dpToPx(8)
 
             cardBinding.root.layoutParams = params
 
@@ -199,7 +198,8 @@ class HealthRecommendFragment : Fragment() {
             },
             onImageLoaded = {
                 if (imageLoadCounter?.decrementAndGet() == 0) {
-                    binding.loadingOverlay.hide()
+                    onImagesLoadedAction?.invoke()
+                    onImagesLoadedAction = null
                 }
             }
         )
@@ -219,6 +219,8 @@ class HealthRecommendFragment : Fragment() {
             } catch (e: Exception) {
                 if (_binding != null) {
                     binding.loadingOverlay.hide()
+                    onImagesLoadedAction?.invoke()
+                    onImagesLoadedAction = null
                 }
             }
         }
@@ -236,7 +238,8 @@ class HealthRecommendFragment : Fragment() {
         if (itemsToShow.isNotEmpty()) {
             imageLoadCounter = AtomicInteger(itemsToShow.size)
         } else {
-            binding.loadingOverlay.hide()
+            onImagesLoadedAction?.invoke()
+            onImagesLoadedAction = null
         }
 
         aiRecipeAdapter.updateList(itemsToShow.toMutableList())
@@ -247,13 +250,14 @@ class HealthRecommendFragment : Fragment() {
         val dialog = showAiRecommendDialog()
         lifecycleScope.launch {
             try {
-                val ocrResponse = ocrRepository.uploadImageForOcr(uri)
-                Log.d("HealthRecommend", "OCR Success: ${ocrResponse.data}")
+                ocrRepository.uploadImageForOcr(uri)
+                Log.d("HealthRecommend", "OCR Success")
+
+                onImagesLoadedAction = {
+                    dialog.dismiss()
+                }
 
                 loadAiRecipes()
-
-                dialog.dismiss()
-                Toast.makeText(requireContext(), "새로운 레시피를 추천받았습니다!", Toast.LENGTH_SHORT).show()
 
             } catch (e: Exception) {
                 dialog.dismiss()

--- a/app/src/main/java/com/example/mumuk/ui/recommend/IngredientAiRecipeAdapter.kt
+++ b/app/src/main/java/com/example/mumuk/ui/recommend/IngredientAiRecipeAdapter.kt
@@ -3,6 +3,7 @@ package com.example.mumuk.ui.recommend
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
+import com.bumptech.glide.Glide
 import com.example.mumuk.data.model.Recipe
 import com.example.mumuk.databinding.ItemRecipeBinding
 import com.example.mumuk.data.api.RetrofitClient
@@ -20,9 +21,15 @@ class IngredientAiRecipeAdapter(
     inner class ViewHolder(val binding: ItemRecipeBinding) : RecyclerView.ViewHolder(binding.root) {
         fun bind(recipe: Recipe, position: Int) {
             binding.recipeTitle.text = recipe.title
-            recipe.img?.let {
-                binding.recipeImg.setImageResource(it)
+
+            recipe.recipeImageUrl?.let {
+                Glide.with(binding.recipeImg.context)
+                    .load(it)
+                    .placeholder(com.example.mumuk.R.drawable.bg_mosaic)
+                    .error(com.example.mumuk.R.drawable.bg_mosaic)
+                    .into(binding.recipeImg)
             }
+
             binding.imageView6.setImageResource(
                 if (recipe.isLiked) com.example.mumuk.R.drawable.btn_heart_fill
                 else com.example.mumuk.R.drawable.btn_heart_blank

--- a/app/src/main/java/com/example/mumuk/ui/recommend/IngredientAiRecipeAdapter.kt
+++ b/app/src/main/java/com/example/mumuk/ui/recommend/IngredientAiRecipeAdapter.kt
@@ -1,9 +1,13 @@
 package com.example.mumuk.ui.recommend
 
+import android.graphics.drawable.Drawable
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
+import com.bumptech.glide.load.DataSource
+import com.bumptech.glide.load.engine.GlideException
+import com.bumptech.glide.request.RequestListener
 import com.example.mumuk.data.model.Recipe
 import com.example.mumuk.databinding.ItemRecipeBinding
 import com.example.mumuk.data.api.RetrofitClient
@@ -15,7 +19,8 @@ import retrofit2.Response
 
 class IngredientAiRecipeAdapter(
     private var items: MutableList<Recipe>,
-    private val onItemClick: (Recipe) -> Unit
+    private val onItemClick: (Recipe) -> Unit,
+    private val onImageLoaded: () -> Unit
 ) : RecyclerView.Adapter<IngredientAiRecipeAdapter.ViewHolder>() {
 
     inner class ViewHolder(val binding: ItemRecipeBinding) : RecyclerView.ViewHolder(binding.root) {
@@ -27,6 +32,28 @@ class IngredientAiRecipeAdapter(
                     .load(it)
                     .placeholder(com.example.mumuk.R.drawable.bg_mosaic)
                     .error(com.example.mumuk.R.drawable.bg_mosaic)
+                    .listener(object : RequestListener<Drawable> {
+                        override fun onLoadFailed(
+                            e: GlideException?,
+                            model: Any?,
+                            target: com.bumptech.glide.request.target.Target<Drawable?>,
+                            isFirstResource: Boolean
+                        ): Boolean {
+                            onImageLoaded()
+                            return false
+                        }
+
+                        override fun onResourceReady(
+                            resource: Drawable,
+                            model: Any,
+                            target: com.bumptech.glide.request.target.Target<Drawable?>?,
+                            dataSource: DataSource,
+                            isFirstResource: Boolean
+                        ): Boolean {
+                            onImageLoaded()
+                            return false
+                        }
+                    })
                     .into(binding.recipeImg)
             }
 

--- a/app/src/main/java/com/example/mumuk/ui/recommend/IngredientRecommendFragment.kt
+++ b/app/src/main/java/com/example/mumuk/ui/recommend/IngredientRecommendFragment.kt
@@ -18,6 +18,7 @@ import com.example.mumuk.data.repository.IngredientAiRecipeRepository
 import com.example.mumuk.data.repository.IngredientRepository
 import com.example.mumuk.databinding.FragmentIngredientRecommendBinding
 import kotlinx.coroutines.launch
+import java.util.concurrent.atomic.AtomicInteger
 
 class IngredientRecommendFragment : Fragment() {
     private var _binding: FragmentIngredientRecommendBinding? = null
@@ -30,11 +31,10 @@ class IngredientRecommendFragment : Fragment() {
     private var aiRecipeList: List<Recipe> = emptyList()
     private var isExpanded = false
 
+    private var imageLoadCounter: AtomicInteger? = null
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        if (aiRecipeList.isEmpty()) {
-            loadAiRecipes()
-        }
     }
 
     override fun onCreateView(
@@ -52,7 +52,6 @@ class IngredientRecommendFragment : Fragment() {
         binding.loadingOverlay.show()
         loadIngredients()
         loadAiRecipes()
-        updateAiRecipeList()
 
         binding.plusBtn.setOnClickListener {
             isExpanded = true
@@ -72,6 +71,11 @@ class IngredientRecommendFragment : Fragment() {
                 Log.d("IngredientRecommend", "Recipe clicked. ID: ${recipe.id}")
                 val bundle = bundleOf("recipeId" to recipe.id)
                 findNavController().navigate(R.id.action_ingredientRecommendFragment_to_recipeFragment, bundle)
+            },
+            onImageLoaded = {
+                if (imageLoadCounter?.decrementAndGet() == 0) {
+                    binding.loadingOverlay.hide()
+                }
             }
         )
         binding.aiRecipeRV.adapter = aiRecipeAdapter
@@ -104,10 +108,8 @@ class IngredientRecommendFragment : Fragment() {
         lifecycleScope.launch {
             try {
                 aiRecipeList = aiRecipeRepository.getAiRecipes()
-                // 뷰가 이미 생성되었다면 UI를 업데이트합니다.
                 if (_binding != null) {
                     updateAiRecipeList()
-                    binding.loadingOverlay.hide()
                 }
             } catch (e: Exception) {
                 if (_binding != null) {
@@ -125,6 +127,13 @@ class IngredientRecommendFragment : Fragment() {
         } else {
             aiRecipeList
         }
+
+        if (itemsToShow.isNotEmpty()) {
+            imageLoadCounter = AtomicInteger(itemsToShow.size)
+        } else {
+            binding.loadingOverlay.hide()
+        }
+
         aiRecipeAdapter.updateList(itemsToShow.toMutableList())
         binding.plusBtn.visibility = if (aiRecipeList.size > 6 && !isExpanded) View.VISIBLE else View.GONE
     }


### PR DESCRIPTION
## ✔️ 작업 내용
- 재료 맞춤 추천 화면 glide 연동
- AI 추천 화면에서 이미지까지 로드돼야 로딩화면 닫히게 수정
- OCR 기능 실행 후 이미지까지 로드돼야 dialog 닫히게 수정

## 💬 참고 사항 <!-- 리뷰어에게 할 말을 작성해주세요. -->
